### PR TITLE
Fix plural of `branches`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
 
 ### Branching conventions
 
-Your branchs must follow a name convention, here's a list of them:
+Your branches must follow a name convention, here's a list of them:
 
  - `release/.*`: labels PR as **feature** and increase the **major**
    version


### PR DESCRIPTION
Just fixes a plural of the word `branches`.