### PR TITLE
No requerir approve para generar un tag

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -71,28 +71,6 @@ async function run() {
                 //     return
                 // }
 
-                // Validate approval:
-                const reviews = await octokit.rest.pulls.listReviews({
-                    owner,
-                    repo,
-                    pull_number: pr.number,
-                    per_page: 100
-                });
-                if(reviews.data.length === 100){
-                    core.warning('max reviews per page, restriction may be false')
-                }
-                let approved = false
-                for (const review of reviews.data) {
-                    if(review.state === 'APPROVED') {
-                        approved = true
-                    }
-                }
-                if(!approved) {
-                    await addComment(pr.number, `:warning: An approval is required to create a release candidate. :warning:`);
-                    core.setFailed('An approval is required to create a release candidate.');
-                    return
-                }
-
                 const newTag = await createTag(pr)
                 if(triggerBuild) {
                     // Trigger build workflow:


### PR DESCRIPTION
## Detalles

En #44 se agregó la necesidad de requerir aprobación para hacer uso del flag de generación de tags. Eso fue una solicitud de nuestro equipo porque tuvimos incidentes con otros equipos que realizaban pruebas o despliegues en producción de aplicaciones de nuestro ownership sin nuestro conocimiento.

Desde entonces el ambiente modificó mucho y esta necesidad de una aprobación se volvió una molestia, las cosas que destaco son:

 - Es necesario que un Admin de aplicación califique las versiones como desplegables
 - Se crearon muchos ambientes de staging y sería conveniente no requerir de este check para realizar pruebas
 - Este check se puede omitir pusheando un tag desde el local